### PR TITLE
Adjust minimum dropout of each frequency bin

### DIFF
--- a/app/src/main/java/net/pmarks/chromadoze/PhononMutable.java
+++ b/app/src/main/java/net/pmarks/chromadoze/PhononMutable.java
@@ -121,6 +121,9 @@ public class PhononMutable implements Phonon {
         return mBars[band] / (float) BAR_MAX;
     }
 
+    /*
+     * Returns the scaled value of all bars from [0.0, 1.0]
+     */
     private float[] getAllBars() {
         float[] out = new float[BAND_COUNT];
         for (int i = 0; i < BAND_COUNT; i++) {

--- a/app/src/main/java/net/pmarks/chromadoze/SpectrumData.java
+++ b/app/src/main/java/net/pmarks/chromadoze/SpectrumData.java
@@ -46,11 +46,26 @@ public class SpectrumData implements Parcelable {
         }
         mData = donateBars;
         for (int i = 0; i < BAND_COUNT; i++) {
-            if (mData[i] <= 0f) {
+            /* Input donateBars values are a linear scale in [0.0, 1.0].
+             * Audio samples are 16 bits per channel or about 48 dB dynamic
+             * range. Scale the input to [-50 dB, 0.0 dB] or [10^-5, 1.0] on
+             * a log scale. As a special case, if the input is 0.0, completely
+             * silence that frequency band.
+             */
+            if (mData[i] < 0.000001f) {
                 mData[i] = 0f;
-            } else {
-                mData[i] = 0.001f * (float) Math.pow(1000, mData[i]);
+                continue;
             }
+            /* This calculation was previously 0.001 * Math.pow(1000f, mData[i])
+             * which is equal to Math.pow(10.0, 3*(mData[i] - 1)). I've changed
+             * the equation to extend the input scaling down to below a single
+             * LSB of audio output to ensure an appropriate volume difference
+             * between the lowest non-zero value of a bin and zero. I've also
+             * refactored the equation to make the relationship to dB clearer.
+             * The exp variable is in units of dB/10.
+             */
+            float exp = 5f*(mData[i] - 1f);
+            mData[i] = (float) Math.pow(10.0, exp);
         }
     }
 


### PR DESCRIPTION
Increases the dynamic range of each frequency band from 30 dB to 50 dB. For a typical audio output resolution of 16 bits a single LSB is `10*log10(1/2^16) = -48.2 dBFS`. Expanding the dynamic range to 50 dB ensures that there is minimal (but nonzero) difference between the minimum non-zero slider value and zero. Previously the difference between the lowest non-zero setting for each frequency band and zero was significant, making it difficult to form a gentle frequency dropoff.

Note that this change will rescale any existing saved spectra.